### PR TITLE
Initialize SwiftUI app skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "RealTimeTranslateApp",
+    platforms: [
+        .macOS(.v13),
+        .iOS(.v16)
+    ],
+    products: [
+        .executable(name: "RealTimeTranslateApp", targets: ["RealTimeTranslateApp"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "RealTimeTranslateApp",
+            path: "Sources/RealTimeTranslateApp"
+        )
+    ]
+)

--- a/Sources/RealTimeTranslateApp/ContentView.swift
+++ b/Sources/RealTimeTranslateApp/ContentView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Welcome to Real-Time Translate")
+            .padding()
+    }
+}
+
+#if DEBUG
+#Preview {
+    ContentView()
+}
+#endif

--- a/Sources/RealTimeTranslateApp/RealTimeTranslateApp.swift
+++ b/Sources/RealTimeTranslateApp/RealTimeTranslateApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct RealTimeTranslateApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/plan.md
+++ b/plan.md
@@ -220,7 +220,7 @@ In summary, robust error handling is built-in at each stage, with user-friendly 
 
 ## Checklist
 
-- [ ] Set up project structure and basic SwiftUI app for iOS/macOS.
+ - [x] Set up project structure and basic SwiftUI app for iOS/macOS.
 - [ ] Implement audio capture with VAD and chunking of speech.
 - [ ] Integrate Whisper API for transcription of each audio chunk.
 - [ ] Implement translation via GPT-4o Mini with streaming response parsing.


### PR DESCRIPTION
## Summary
- create a Package.swift with iOS/macOS platforms
- add minimal SwiftUI app and content view
- update checklist in plan.md to mark first step complete

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_684c03910a788325b0e919396aa1dd5b