### PR TITLE
Add settings screen

### DIFF
--- a/Sources/RealTimeTranslateApp/ContentView.swift
+++ b/Sources/RealTimeTranslateApp/ContentView.swift
@@ -2,10 +2,9 @@ import SwiftUI
 
 struct ContentView: View {
     @StateObject private var viewModel = SpeechTranslationViewModel(
-        service: TranslationService(
-            config: .init(apiKey: "YOUR_API_KEY", targetLanguage: "French")
-        )
+        service: TranslationService(config: .load())
     )
+    @State private var showingSettings = false
 
     var body: some View {
         VStack {
@@ -27,6 +26,12 @@ struct ContentView: View {
             .padding()
         }
         .padding()
+        .toolbar {
+            Button("Settings") { showingSettings = true }
+        }
+        .sheet(isPresented: $showingSettings) {
+            SettingsView(service: viewModel.service)
+        }
     }
 }
 

--- a/Sources/RealTimeTranslateApp/SettingsView.swift
+++ b/Sources/RealTimeTranslateApp/SettingsView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @ObservedObject var service: TranslationService
+    @Environment(\.dismiss) private var dismiss
+    @AppStorage("apiKey") private var apiKey: String = ""
+    @AppStorage("targetLanguage") private var targetLanguage: String = "French"
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section(header: Text("OpenAI API")) {
+                    SecureField("API Key", text: $apiKey)
+                }
+                Section(header: Text("Translation Settings")) {
+                    Picker("Target Language", selection: $targetLanguage) {
+                        Text("French").tag("French")
+                        Text("German").tag("German")
+                    }
+                    .pickerStyle(SegmentedPickerStyle())
+                }
+            }
+            .navigationTitle("Settings")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") {
+                        service.config = .init(apiKey: apiKey, targetLanguage: targetLanguage)
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+#if DEBUG
+#Preview {
+    SettingsView(service: TranslationService(config: .init(apiKey: "", targetLanguage: "French")))
+}
+#endif

--- a/Sources/RealTimeTranslateApp/SpeechTranslationViewModel.swift
+++ b/Sources/RealTimeTranslateApp/SpeechTranslationViewModel.swift
@@ -17,7 +17,7 @@ final class SpeechTranslationViewModel: ObservableObject {
     @Published var messages: [Message] = []
 
     private let audioManager = AudioCaptureManager()
-    private let service: TranslationService
+    let service: TranslationService
     private let tts = TextToSpeechManager()
     private var cancellables: Set<AnyCancellable> = []
 

--- a/Sources/RealTimeTranslateApp/TranslationService.swift
+++ b/Sources/RealTimeTranslateApp/TranslationService.swift
@@ -3,13 +3,26 @@ import Combine
 
 /// Handles communication with OpenAI's APIs for transcription and translation.
 /// This example focuses on function signatures and streaming parsing rather than real network calls.
-final class TranslationService {
+final class TranslationService: ObservableObject {
     struct Config {
         var apiKey: String
         var targetLanguage: String
+
+        static func load() -> Config {
+            let defaults = UserDefaults.standard
+            let key = defaults.string(forKey: "apiKey") ?? ""
+            let language = defaults.string(forKey: "targetLanguage") ?? "French"
+            return .init(apiKey: key, targetLanguage: language)
+        }
     }
 
-    @Published var config: Config
+    @Published var config: Config {
+        didSet {
+            let defaults = UserDefaults.standard
+            defaults.set(config.apiKey, forKey: "apiKey")
+            defaults.set(config.targetLanguage, forKey: "targetLanguage")
+        }
+    }
 
     init(config: Config) {
         self.config = config

--- a/plan.md
+++ b/plan.md
@@ -227,7 +227,7 @@ In summary, robust error handling is built-in at each stage, with user-friendly 
 - [x] Add real-time UI updates showing transcribed and translated text.
 - [x] Implement TTS playback with language detection and audio saving.
 - [ ] Add data storage (Core Data and audio files) for conversations.
-- [ ] Implement settings view for API key and language options.
+- [x] Implement settings view for API key and language options.
 - [ ] Implement history view to browse past conversations.
 - [ ] Add comprehensive error handling and retries for network/API failures.
 - [ ] Polish UI/UX with waveform indicator and playback controls.
@@ -242,6 +242,7 @@ Initial implementation includes:
 * Added network layer for Whisper API with multipart upload support.
 * Implemented streaming translation via GPT-4o Mini using URLSession SSE parsing.
 * Added `TextToSpeechManager` for speaking translations and saving them to audio files.
+* Added `SettingsView` allowing API key entry and language selection.
 
 ## Next Steps
 
@@ -250,7 +251,7 @@ Initial implementation includes:
 3. ~~Bind results to a dedicated view model so `ContentView` updates in real time.~~ (done)
 4. ~~Develop `TextToSpeechManager` to play and store synthesized speech audio.~~ (done)
 5. ~~Set up Core Data models (`ConversationSession` and `Utterance`) to persist conversations incrementally.~~ (done)
-6. Create a settings screen for API key entry and language selection.
+6. ~~Create a settings screen for API key entry and language selection.~~ (done)
 7. Build a history interface showing past sessions with playback controls.
 8. Add robust error handling and retry logic around all network calls.
 9. Polish the interface with waveform visualization and platform-specific design tweaks.


### PR DESCRIPTION
## Summary
- add user-configurable API key and language settings
- persist API key and target language
- wire settings UI into main view
- note new settings in development plan

## Testing
- `swift build` *(fails: no such module 'AVFoundation')*

------
https://chatgpt.com/codex/tasks/task_e_684c3a3534d483259a957c38a14ac790