### PR TITLE
Implement history playback interface

### DIFF
--- a/Sources/RealTimeTranslateApp/ContentView.swift
+++ b/Sources/RealTimeTranslateApp/ContentView.swift
@@ -5,6 +5,7 @@ struct ContentView: View {
         service: TranslationService(config: .load())
     )
     @State private var showingSettings = false
+    @State private var showingHistory = false
 
     var body: some View {
         VStack {
@@ -27,10 +28,15 @@ struct ContentView: View {
         }
         .padding()
         .toolbar {
+            Button("History") { showingHistory = true }
             Button("Settings") { showingSettings = true }
         }
         .sheet(isPresented: $showingSettings) {
             SettingsView(service: viewModel.service)
+        }
+        .sheet(isPresented: $showingHistory) {
+            HistoryView()
+                .environment(\.managedObjectContext, PersistenceController.shared.container.viewContext)
         }
     }
 }

--- a/Sources/RealTimeTranslateApp/CoreDataModels.swift
+++ b/Sources/RealTimeTranslateApp/CoreDataModels.swift
@@ -15,3 +15,6 @@ class Utterance: NSManagedObject {
     @NSManaged var audioPath: String?
     @NSManaged var session: ConversationSession
 }
+
+extension ConversationSession: Identifiable {}
+extension Utterance: Identifiable {}

--- a/Sources/RealTimeTranslateApp/HistoryView.swift
+++ b/Sources/RealTimeTranslateApp/HistoryView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+import CoreData
+import AVFoundation
+
+struct HistoryView: View {
+    @Environment(\.managedObjectContext) private var context
+    @FetchRequest(
+        entity: ConversationSession.entity(),
+        sortDescriptors: [NSSortDescriptor(keyPath: \ConversationSession.timestamp, ascending: false)]
+    ) private var sessions: FetchedResults<ConversationSession>
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(sessions) { session in
+                    NavigationLink(value: session) {
+                        Text(session.timestamp, style: .date)
+                    }
+                }
+            }
+            .navigationTitle("History")
+            .navigationDestination(for: ConversationSession.self) { session in
+                SessionDetailView(session: session)
+            }
+        }
+    }
+}
+
+private struct SessionDetailView: View {
+    @ObservedObject var session: ConversationSession
+    @State private var audioPlayer: AVAudioPlayer?
+
+    private var utterances: [Utterance] {
+        Array(session.utterances).sorted { $0.original < $1.original }
+    }
+
+    var body: some View {
+        List(utterances) { utt in
+            VStack(alignment: .leading) {
+                Text(utt.original)
+                    .font(.body)
+                Text(utt.translated)
+                    .font(.callout)
+                    .foregroundColor(.blue)
+                if let path = utt.audioPath {
+                    Button("Play") { play(url: URL(fileURLWithPath: path)) }
+                        .buttonStyle(.borderedProminent)
+                }
+            }
+            .padding(.vertical, 4)
+        }
+        .navigationTitle(session.timestamp, format: .dateTime)
+    }
+
+    private func play(url: URL) {
+        audioPlayer?.stop()
+        do {
+            audioPlayer = try AVAudioPlayer(contentsOf: url)
+            audioPlayer?.play()
+        } catch {
+            print("Audio playback error: \(error)")
+        }
+    }
+}
+
+#if DEBUG
+#Preview {
+    HistoryView()
+        .environment(\.managedObjectContext, PersistenceController.shared.container.viewContext)
+}
+#endif

--- a/plan.md
+++ b/plan.md
@@ -226,9 +226,9 @@ In summary, robust error handling is built-in at each stage, with user-friendly 
 - [x] Implement translation via GPT-4o Mini with streaming response parsing.
 - [x] Add real-time UI updates showing transcribed and translated text.
 - [x] Implement TTS playback with language detection and audio saving.
-- [ ] Add data storage (Core Data and audio files) for conversations.
+- [x] Add data storage (Core Data and audio files) for conversations.
 - [x] Implement settings view for API key and language options.
-- [ ] Implement history view to browse past conversations.
+- [x] Implement history view to browse past conversations.
 - [ ] Add comprehensive error handling and retries for network/API failures.
 - [ ] Polish UI/UX with waveform indicator and playback controls.
 - [ ] Final testing across iOS and macOS.
@@ -252,7 +252,7 @@ Initial implementation includes:
 4. ~~Develop `TextToSpeechManager` to play and store synthesized speech audio.~~ (done)
 5. ~~Set up Core Data models (`ConversationSession` and `Utterance`) to persist conversations incrementally.~~ (done)
 6. ~~Create a settings screen for API key entry and language selection.~~ (done)
-7. Build a history interface showing past sessions with playback controls.
+7. ~~Build a history interface showing past sessions with playback controls.~~ (done)
 8. Add robust error handling and retry logic around all network calls.
 9. Polish the interface with waveform visualization and platform-specific design tweaks.
 10. Perform full end-to-end testing on both iOS and macOS.


### PR DESCRIPTION
## Summary
- implement `HistoryView` with session playback
- add Identifiable conformance for Core Data models
- expose `HistoryView` from `ContentView`
- mark history step done in plan

## Testing
- `swift build` *(fails: no such module 'AVFoundation')*

------
https://chatgpt.com/codex/tasks/task_e_684c3b4c09808325a5fd497527d586c6