### PR TITLE
Fix history view navigation title format

### DIFF
--- a/Sources/RealTimeTranslateApp/HistoryView.swift
+++ b/Sources/RealTimeTranslateApp/HistoryView.swift
@@ -49,7 +49,7 @@ private struct SessionDetailView: View {
             }
             .padding(.vertical, 4)
         }
-        .navigationTitle(session.timestamp, format: .dateTime)
+        .navigationTitle(Text(session.timestamp, format: .dateTime))
     }
 
     private func play(url: URL) {


### PR DESCRIPTION
## Summary
- fix compile error in `HistoryView` when setting navigation title

## Testing
- `swift build` *(fails: no such module 'AVFoundation')*

------
https://chatgpt.com/codex/tasks/task_e_684c3e425a9c832582367866628e4d91