### PR TITLE
Fix macOS run to show window

### DIFF
--- a/Sources/RealTimeTranslateApp/RealTimeTranslateApp.swift
+++ b/Sources/RealTimeTranslateApp/RealTimeTranslateApp.swift
@@ -1,8 +1,19 @@
 import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
 
 @main
 struct RealTimeTranslateApp: App {
     let persistence = PersistenceController.shared
+    init() {
+#if os(macOS)
+        // Ensure the app shows a dock icon and its windows become visible when
+        // running as a command-line executable on macOS.
+        NSApplication.shared.setActivationPolicy(.regular)
+        NSApplication.shared.activate(ignoringOtherApps: true)
+#endif
+    }
     var body: some Scene {
         WindowGroup {
             ContentView()


### PR DESCRIPTION
## Summary
- show macOS window when run as executable by activating NSApplication

## Testing
- `swift test -c release` *(fails: no such module 'AVFoundation')*

------
https://chatgpt.com/codex/tasks/task_e_684c4115713483259189c69d27efe52d