### PR TITLE
Fix audio format mismatch when starting capture

### DIFF
--- a/Sources/RealTimeTranslateApp/AudioCaptureManager.swift
+++ b/Sources/RealTimeTranslateApp/AudioCaptureManager.swift
@@ -30,10 +30,13 @@ final class AudioCaptureManager: ObservableObject {
         buffer = nil
         lastSpeechTime = CACurrentMediaTime()
 
+        // Start engine first so the input node's format matches the hardware
+        try engine.start()
+        recognitionFormat = inputNode.outputFormat(forBus: 0)
+
         inputNode.installTap(onBus: 0, bufferSize: 1024, format: recognitionFormat) { [weak self] pcmBuffer, _ in
             self?.process(buffer: pcmBuffer)
         }
-        try engine.start()
     }
 
     /// Stops the audio engine and clears state.


### PR DESCRIPTION
## Summary
- start `AVAudioEngine` before installing tap on the microphone
- update recognition format after the engine starts so it matches the hardware

## Testing
- `swift test` *(fails: no such module 'AVFoundation')*

------
https://chatgpt.com/codex/tasks/task_e_684c44090f508325bd9b3e57922d80f2