### PR TITLE
Fix optional voice usage

### DIFF
--- a/Sources/RealTimeTranslateApp/TextToSpeechManager.swift
+++ b/Sources/RealTimeTranslateApp/TextToSpeechManager.swift
@@ -13,11 +13,13 @@ final class TextToSpeechManager {
     /// - Returns: The file URL of the saved WAV audio.
     @MainActor
     func speak(text: String, language: String) async throws -> URL {
-        let voice = AVSpeechSynthesisVoice(language: language) ?? AVSpeechSynthesisVoice(language: "en-US")
+        let voice = AVSpeechSynthesisVoice(language: language) ??
+            AVSpeechSynthesisVoice(language: "en-US")
         let utterance = AVSpeechUtterance(string: text)
         utterance.voice = voice
 
-        print("[TTS] speaking with voice \(voice.language)")
+        let voiceLanguage = voice?.language ?? "unknown"
+        print("[TTS] speaking with voice \(voiceLanguage)")
 
         // Speak the utterance aloud immediately
         speakSynthesizer.stopSpeaking(at: .immediate)


### PR DESCRIPTION
## Summary
- unwrap optional `AVSpeechSynthesisVoice` when printing its language

## Testing
- `swift test -v` *(fails: no such module 'AVFoundation')*
- `swift build` *(fails: no such module 'AVFoundation')*

------
https://chatgpt.com/codex/tasks/task_e_684c49e05e7083259044541172e7f608